### PR TITLE
feat: add containerStyle prop to ExpoLiquidGlassView

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ export default function App() {
       tint="#000000"
       cornerRadius={24}
       style={{ width: 200, height: 200, alignSelf: "center", marginTop: 100 }}
+      containerStyle={{ padding: 16, alignItems: "center" }}
     >
       <Text style={{ color: "#fff", textAlign: "center" }}>
         Liquid Glass ✨
@@ -82,7 +83,8 @@ export default function App() {
 | `tint`         | `string`                                                        | `undefined`    | Optional iOS system tint, like `"systemUltraThinMaterial"` or custom color |
 | `cornerRadius` | `number`                                                        | `12`           | Border radius in points                                                    |
 | `cornerStyle`  | `"continuous"` \| `"circular"`                                  | `"continuous"` | Defines the curvature style of the corners                                 |
-| `style`        | `StyleProp<ViewStyle>`                                          | `undefined`    | React Native style object                                                  |
+| `style`        | `StyleProp<ViewStyle>`                                          | `undefined`    | Style for the outer native glass view                                      |
+| `containerStyle` | `StyleProp<ViewStyle>`                                        | `undefined`    | Style for the inner content container that wraps `children`                |
 | `children`     | `React.ReactNode`                                               | `undefined`    | Optional React children to render inside the glass                         |
 
 ---
@@ -109,6 +111,7 @@ export interface ExpoLiquidGlassViewProps {
   cornerRadius?: number;
   cornerStyle?: CornerStyle;
   style?: StyleProp<ViewStyle>;
+  containerStyle?: StyleProp<ViewStyle>;
   children?: React.ReactNode;
 }
 ```

--- a/src/ExpoLiquidGlassView.tsx
+++ b/src/ExpoLiquidGlassView.tsx
@@ -10,14 +10,15 @@ const NativeView: React.ComponentType<ExpoLiquidGlassViewProps> =
   );
 
 export function ExpoLiquidGlassView(props: ExpoLiquidGlassViewProps) {
+  const { children, containerStyle, style, ...nativeProps } = props;
+
   return (
     <NativeView
-      {...props}
-      style={[styles.wrapper, props.style]}
-      key={Math.random().toString()}
+      {...nativeProps}
+      style={[styles.wrapper, style]}
     >
-      {props.children ? (
-        <View style={styles.container}>{props.children}</View>
+      {children ? (
+        <View style={[styles.container, containerStyle]}>{children}</View>
       ) : null}
     </NativeView>
   );

--- a/src/ExpoLiquidGlassView.types.ts
+++ b/src/ExpoLiquidGlassView.types.ts
@@ -21,5 +21,6 @@ export interface ExpoLiquidGlassViewProps {
   isInteractive?: boolean;
   cornerStyle?: CornerStyle;
   style?: StyleProp<ViewStyle>;
+  containerStyle?: StyleProp<ViewStyle>;
   children?: React.ReactNode;
 }


### PR DESCRIPTION
## Summary
This PR adds support for styling the inner content wrapper of `ExpoLiquidGlassView`.

### Changes
- Added `containerStyle?: StyleProp<ViewStyle>` to `ExpoLiquidGlassViewProps`
- Applied `containerStyle` to the internal `<View>` that wraps `children`
- Kept `style` scoped to the outer native glass view (clear separation of concerns)
- Removed random `key` usage from `ExpoLiquidGlassView` to avoid unnecessary remounts
- Updated README usage example, props table, and types section

## Why
Previously, consumers could only style the outer glass view via `style`.  
With `containerStyle`, consumers can now control inner layout concerns (like padding, alignment, spacing) without affecting the native wrapper styles.

## Backward Compatibility
- No breaking changes
- Existing `style` usage continues to work as before